### PR TITLE
Use correct field separator in keywords.txt

### DIFF
--- a/keywords.txt
+++ b/keywords.txt
@@ -10,32 +10,32 @@
 # Methods and Functions (KEYWORD2)
 #######################################
 
-begin   KEYWORD2
+begin	KEYWORD2
 addWiFi	KEYWORD2
 addCloudToken	KEYWORD2
 addUbiDotsToken	KEYWORD2
 addBlynkToken	KEYWORD2
 addAzureToken	KEYWORD2
-addMQTT KEYWORD2
-optionBlinkLED  KEYWORD2
-printConfigJson KEYWORD2
-transmit    KEYWORD2
-receive KEYWORD2
-success KEYWORD2
-getWiFi KEYWORD2
-getMQTT KEYWORD2
-getUbiDotsToken KEYWORD2
-getAzureToken   KEYWORD2
-getBlynkToken   KEYWORD2
-getCloudToken   KEYWORD2
-enableLED   KEYWORD2
-BlinkLED    KEYWORD2
-fail    KEYWORD2
-end KEYWORD2
-addVariable KEYWORD2
-getVariable KEYWORD2
-addCustomJson   KEYWORD2
-reset   KEYWORD2
+addMQTT	KEYWORD2
+optionBlinkLED	KEYWORD2
+printConfigJson	KEYWORD2
+transmit	KEYWORD2
+receive	KEYWORD2
+success	KEYWORD2
+getWiFi	KEYWORD2
+getMQTT	KEYWORD2
+getUbiDotsToken	KEYWORD2
+getAzureToken	KEYWORD2
+getBlynkToken	KEYWORD2
+getCloudToken	KEYWORD2
+enableLED	KEYWORD2
+BlinkLED	KEYWORD2
+fail	KEYWORD2
+end	KEYWORD2
+addVariable	KEYWORD2
+getVariable	KEYWORD2
+addCustomJson	KEYWORD2
+reset	KEYWORD2
 
 #######################################
 # Constants	(LITERAL1)


### PR DESCRIPTION
The Arduino IDE requires the use of a single true tab separator between the keyword name and identifier. When spaces are used rather than a true tab, the keyword is not highlighted.

Reference:
https://github.com/arduino/Arduino/wiki/Arduino-IDE-1.5:-Library-specification#keywords